### PR TITLE
Font Library Modal: Adds warning/info notice support

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/context.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/context.js
@@ -218,6 +218,8 @@ function FontLibraryProvider( { children } ) {
 		try {
 			const fontFamiliesToActivate = [];
 			let installationErrors = [];
+			let installationInfos = [];
+			let installationWarnings = [];
 
 			for ( const fontFamilyToInstall of fontFamiliesToInstall ) {
 				let isANewFontFamily = false;
@@ -265,14 +267,18 @@ function FontLibraryProvider( { children } ) {
 
 				// Install the fonts (upload the font files to the server and create the post in the database).
 				let sucessfullyInstalledFontFaces = [];
-				let unsucessfullyInstalledFontFaces = [];
+				let unsucessfullyInstalledFontFacesError = [];
+				let unsucessfullyInstalledFontFacesWarning = [];
+				let unsucessfullyInstalledFontFacesInfo = [];
 				if ( fontFamilyToInstall?.fontFace?.length > 0 ) {
 					const response = await batchInstallFontFaces(
 						installedFontFamily.id,
 						makeFontFacesFormData( fontFamilyToInstall )
 					);
 					sucessfullyInstalledFontFaces = response?.successes;
-					unsucessfullyInstalledFontFaces = response?.errors;
+					unsucessfullyInstalledFontFacesError = response?.errors;
+					unsucessfullyInstalledFontFacesWarning = response?.warnings;
+					unsucessfullyInstalledFontFacesInfo = response?.infos;
 				}
 
 				// Use the sucessfully installed font faces
@@ -308,11 +314,35 @@ function FontLibraryProvider( { children } ) {
 				}
 
 				installationErrors = installationErrors.concat(
-					unsucessfullyInstalledFontFaces
+					unsucessfullyInstalledFontFacesError
+				);
+
+				installationWarnings = installationWarnings.concat(
+					unsucessfullyInstalledFontFacesWarning
+				);
+
+				installationInfos = installationInfos.concat(
+					unsucessfullyInstalledFontFacesInfo
 				);
 			}
 
 			installationErrors = installationErrors.reduce(
+				( unique, item ) =>
+					unique.includes( item.message )
+						? unique
+						: [ ...unique, item.message ],
+				[]
+			);
+
+			installationInfos = installationInfos.reduce(
+				( unique, item ) =>
+					unique.includes( item.message )
+						? unique
+						: [ ...unique, item.message ],
+				[]
+			);
+
+			installationWarnings = installationWarnings.reduce(
 				( unique, item ) =>
 					unique.includes( item.message )
 						? unique
@@ -343,6 +373,22 @@ function FontLibraryProvider( { children } ) {
 				installError.installationErrors = installationErrors;
 
 				throw installError;
+			}
+
+			if ( installationWarnings.length > 0 ) {
+				const installWarning = new Error( __( 'Warning.' ) );
+
+				installWarning.installationWarnings = installationWarnings;
+
+				throw installWarning;
+			}
+
+			if ( installationInfos.length > 0 ) {
+				const installInfo = new Error( __( 'Info.' ) );
+
+				installInfo.installationInfos = installationInfos;
+
+				throw installInfo;
 			}
 		} finally {
 			setIsInstalling( false );

--- a/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/upload-fonts.js
@@ -187,11 +187,30 @@ function UploadFonts() {
 				message: __( 'Fonts were installed successfully.' ),
 			} );
 		} catch ( error ) {
-			setNotice( {
-				type: 'error',
-				message: error.message,
-				errors: error?.installationErrors,
-			} );
+			if ( error?.installationErrors ) {
+				setNotice( {
+					type: 'error',
+					message: error.message,
+					errors: error?.installationErrors,
+				} );
+			} else if ( error?.installationWarnings ) {
+				setNotice( {
+					type: 'warning',
+					message: error.message,
+					errors: error?.installationWarnings,
+				} );
+			} else if ( error?.installationInfos ) {
+				setNotice( {
+					type: 'info',
+					message: error.message,
+					errors: error?.installationInfos,
+				} );
+			} else {
+				setNotice( {
+					type: 'error',
+					message: error.message,
+				} );
+			}
 		}
 
 		setIsUploading( false );

--- a/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/utils/index.js
@@ -236,6 +236,9 @@ export function makeFontFacesFormData( font ) {
 export async function batchInstallFontFaces( fontFamilyId, fontFacesData ) {
 	const responses = [];
 
+	const informationCodes = [ 'rest_duplicate_font_face' ];
+	const warningCodes = [];
+
 	/*
 	 * Uses the same response format as Promise.allSettled, but executes requests in sequence to work
 	 * around a race condition that can cause an error when the fonts directory doesn't exist yet.
@@ -255,6 +258,8 @@ export async function batchInstallFontFaces( fontFamilyId, fontFacesData ) {
 	const results = {
 		errors: [],
 		successes: [],
+		infos: [],
+		warnings: [],
 	};
 
 	responses.forEach( ( result, index ) => {
@@ -268,6 +273,16 @@ export async function batchInstallFontFaces( fontFamilyId, fontFacesData ) {
 					message: `Error: ${ response.message }`,
 				} );
 			}
+		} else if ( informationCodes.includes( result?.reason?.code ) ) {
+			results.infos.push( {
+				data: fontFacesData[ index ],
+				message: result.reason.message,
+			} );
+		} else if ( warningCodes.includes( result?.reason?.code ) ) {
+			results.warnings.push( {
+				data: fontFacesData[ index ],
+				message: result.reason.message,
+			} );
 		} else {
 			// Handle network errors or other fetch-related errors
 			results.errors.push( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- This PR 
    - adds warning/info notice support to `upload fonts` modal.
    - adds functionality to bifurcate the font upload api errors into, info, warning & error.
- Converts `Font Not Found` error to (info) notice.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- If the font already exists, it is not an error, and should not scare the user.
- This will give contributors an option to bifurcate errors into warnings & info.
- Currently every error returned via rest-api end point is displayed as error but as we are using [Notices](https://developer.wordpress.org/block-editor/reference-guides/components/notice/) on user end to display those errors, we can bifurcate them into errors/warnings/infos to give user correct information.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- When a WP_Error is returned from API, we always have an error code. Using this error codes, we are bifurcating errors into errors/warnings/information(infos). More of, using this we are prioritising the errors.
- This way we can increase our user experience.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a fresh WordPress instance.
2. Open wp-admin > Appearance > Editor.
    <img width="1440" alt="Screenshot 2024-04-09 at 4 05 40 PM" src="https://github.com/Pathan-Amaankhan/gutenberg/assets/63953699/c59853ed-be40-4683-b25b-06e37dccbb46">
3. Open Styles > Edit Styles > Typography > Manage Fonts > Upload.
    <img width="1440" alt="Screenshot 2024-04-09 at 4 07 46 PM" src="https://github.com/Pathan-Amaankhan/gutenberg/assets/63953699/39da8a13-955d-42f2-aa4f-a07d6662173c">
    <img width="1440" alt="Screenshot 2024-04-09 at 4 07 55 PM" src="https://github.com/Pathan-Amaankhan/gutenberg/assets/63953699/6d2ad9dc-abb6-4a56-ab33-af8282c39958">
    <img width="1440" alt="Screenshot 2024-04-09 at 4 08 04 PM" src="https://github.com/Pathan-Amaankhan/gutenberg/assets/63953699/6eede0a1-ddcf-4ef3-bf33-eb0ce31ace3b">
    <img width="1440" alt="Screenshot 2024-04-09 at 4 08 14 PM" src="https://github.com/Pathan-Amaankhan/gutenberg/assets/63953699/9200d907-f7ca-45b3-bb1b-4e426e4a0c43">
    <img width="1440" alt="Screenshot 2024-04-09 at 4 08 29 PM" src="https://github.com/Pathan-Amaankhan/gutenberg/assets/63953699/efecea8d-8f91-4053-8cb9-f37ce5245542">
4. Try uploading same fonts twice. An info notice should be visible instead of an error notice.


## Screenshots/Screencast

#### Before

https://github.com/Pathan-Amaankhan/gutenberg/assets/63953699/7319cabd-2d7e-4818-9394-43f59c87c8d7


#### After


https://github.com/Pathan-Amaankhan/gutenberg/assets/63953699/7ecffd9a-3c31-4ca9-a467-e8190e60402d

